### PR TITLE
Revamp OutlawTwin greenzone experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# TwinCoder Outlaw GreenZone
+
+Bienvenue dans la version remaniée par OutlawTwin / TwinCoder du script de zones vertes pour FiveM. Cette édition supprime les anciennes références, ajoute une interface utilisateur stylée et offre une expérience bilingue prête pour la production.
+
+## ✨ Features / Fonctionnalités
+- **Twin Designer UI** – Review zone settings through a sleek summary panel before publishing.
+- **Branded Zones** – Notifications, blips and presets carry the OutlawTwin identity.
+- **Bilingual Locales** – English and French JSON locales included. Select your language via `ox_lib` configuration.
+- **Custom Commands** – `/outlawzone` to create and `/outlawclear` to remove temporary safe zones.
+- **Default Sanctuaries** – Hospital, police plaza and mountain retreat preconfigured with OutlawTwin styling.
+
+## ⚙️ Requirements / Prérequis
+- [ox_lib](https://github.com/overextended/ox_lib) (locale & math modules enabled in `fxmanifest.lua`).
+- FiveM server running the `cerulean` build or newer.
+
+## 🚀 Installation
+1. Copy the folder into your server resources directory.
+2. Ensure `ox_lib` is started before `Outlaw_GreenZone`.
+3. Add the resource to your `server.cfg`:
+   ```cfg
+   ensure Outlaw_GreenZone
+   ```
+4. (Optional) Set the desired locale in `ox_lib` (defaults to English).
+
+## 🕹️ Usage / Utilisation
+- Run `/outlawzone` as an admin to open the OutlawTwin designer.
+- Fill out the dialog, confirm the summary card, and the zone spawns instantly for all players.
+- Remove the active temporary zone with `/outlawclear`.
+
+## 🛠️ Configuration / Personnalisation
+- Edit `config.lua` to tweak default persistent zones, notification behaviour and designer commands.
+- Adjust colours, text and icons directly in the locale files (`locales/en.json`, `locales/fr.json`).
+- To add more preset zones, duplicate an entry inside `Config.GreenZones` and adjust the coordinates / radius.
+
+## 🤝 Credits
+Crafted with ❤️ by **OutlawTwin Studio / TwinCoder**.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Bienvenue dans la version remaniée par OutlawTwin / TwinCoder du script de zones vertes pour FiveM. Cette édition supprime les anciennes références, ajoute une interface utilisateur stylée et offre une expérience bilingue prête pour la production.
 
 ## ✨ Features / Fonctionnalités
-- **Twin Designer UI** – Review zone settings through a sleek summary panel before publishing.
+- **Twin Designer UI** – Configure zones inside an OutlawTwin-branded tablet interface with live sliders and toggles.
 - **Branded Zones** – Notifications, blips and presets carry the OutlawTwin identity.
 - **Bilingual Locales** – English and French JSON locales included. Select your language via `ox_lib` configuration.
 - **Custom Commands** – `/outlawzone` to create and `/outlawclear` to remove temporary safe zones.
@@ -24,7 +24,7 @@ Bienvenue dans la version remaniée par OutlawTwin / TwinCoder du script de zone
 
 ## 🕹️ Usage / Utilisation
 - Run `/outlawzone` as an admin to open the OutlawTwin designer.
-- Fill out the dialog, confirm the summary card, and the zone spawns instantly for all players.
+- Ajustez le nom, la bannière, le rayon, les limitations de vitesse et les options de combat directement dans l'interface.
 - Remove the active temporary zone with `/outlawclear`.
 
 ## 🛠️ Configuration / Personnalisation

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,3 +1,5 @@
+local locale = lib.locale()
+
 local greenZone = nil
 local vehiclesInZone = nil
 local adminZoneMenu = nil

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,4 +1,6 @@
-local locale = lib.locale()
+local locale = lib and lib.locale or function(phrase)
+    return phrase
+end
 
 local greenZone = nil
 local zone = lib.points.new(vec3(0, 0, 0), 0)

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,6 @@
-local locale = lib.locale()
+local locale = lib and lib.locale or function(phrase)
+    return phrase
+end
 
 Config = {}
 

--- a/config.lua
+++ b/config.lua
@@ -1,3 +1,5 @@
+local locale = lib.locale()
+
 Config = {}
 
 Config.EnableNotifications = false -- Toggle OutlawTwin styled notifications for preconfigured GreenZones

--- a/config.lua
+++ b/config.lua
@@ -1,11 +1,11 @@
 Config = {}
 
-Config.EnableNotifications = false -- Do you want notifications when a player enters and exits the preconfigured greenzones (The Config.GreenZones)?
-Config.GreenzonesCommand = 'setzone' -- The command to run in-game to start creating a temporary greenzone
-Config.GreenzonesClearCommand = 'clearzone' -- The command to run in-game to clear an existing temporary greenzone
+Config.EnableNotifications = false -- Toggle OutlawTwin styled notifications for preconfigured GreenZones
+Config.GreenzonesCommand = 'outlawzone' -- Command used to start the TwinCoder Outlaw zone designer
+Config.GreenzonesClearCommand = 'outlawclear' -- Command used to remove the active TwinCoder Outlaw zone
 
 Config.GreenZones = { -- These are persistent greenzones that exist constantly, at all times - you can create as many as you want here
-    ['hospital'] = {
+    ['twin_medic_haven'] = {
         coords = vec3(299.2270, -584.6892, 43.2608), -- The center-most location of the greenzone
         radius = 100.0, -- The radius (how large or small) the greenzone is (note: this must include the .0 on the end of the number to work)
         disablePlayerVehicleCollision = false, -- Do you want to disable players & their vehicles collisions between each other? (true if yes, false if no)
@@ -15,7 +15,7 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         disableFiring = true, -- Do you want to disable everyone from firing weapons/punching/etc in this zone? (true if yes, false if no)
         setInvincible = true, -- Do you want everyone to be invincible in this zone? (true if yes, false if no)
         displayTextUI = true, -- Do you want textUI to display on everyones screen while in this zone? (true if yes, false if no)
-        textToDisplay = 'Hospital Green Zone', -- The text to display on everyones screen if displayTextUI is true for this zone
+        textToDisplay = 'OutlawTwin Medical Sanctuary', -- The text to display on everyones screen if displayTextUI is true for this zone
         backgroundColorTextUI = '#ff5a47', -- The color of the textUI background to display if displayTextUI is true for this zone
         textColor = '#000000', -- The color of the text & icon itself on the textUI if displayTextUI is true for this zone
         displayTextPosition = 'top-center', -- The position of the textUI if displayTextUI is true for this zone
@@ -27,9 +27,9 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         blipColor = 2, -- Blip color (https://docs.fivem.net/docs/game-references/blips/#blip-colors)
         blipScale = 0.7, -- Blip size (0.01 to 1.0) (only used if enableSprite = true, otherwise can be ignored)
         blipAlpha = 100, -- The transparency of the radius blip if blipType = 'radius', otherwise not used/can be ignored
-        blipName = 'Hospital Greenzone' -- Blip name on the map (if enableSprite = true, otherwise can be ignored)
+        blipName = 'OutlawTwin Medical Sanctuary' -- Blip name on the map (if enableSprite = true, otherwise can be ignored)
     },
-    ['policestation'] = {
+    ['twin_pd_plaza'] = {
         coords = vec3(432.7403, -982.1954, 30.7105),
         radius = 100.0,
         disablePlayerVehicleCollision = false,
@@ -39,7 +39,7 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         disableFiring = true,
         setInvincible = false,
         displayTextUI = true,
-        textToDisplay = 'Police Green Zone',
+        textToDisplay = 'OutlawTwin Justice Plaza',
         backgroundColorTextUI = '#ff5a47',
         textColor = '#000000',
         displayTextPosition = 'top-center',
@@ -51,9 +51,9 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         blipColor = 2,
         blipScale = 0.7,
         blipAlpha = 100,
-        blipName = 'LSPD Greenzone'
+        blipName = 'OutlawTwin Justice Plaza'
     },
-    ['examplelocation3'] = {
+    ['twin_highlands'] = {
         coords = vec3(-1243.6606, 1348.0383, 212.7915),
         radius = 200.0,
         disablePlayerVehicleCollision = false,
@@ -63,7 +63,7 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         disableFiring = false,
         setInvincible = true,
         displayTextUI = true,
-        textToDisplay = 'Random Green Zone',
+        textToDisplay = 'Outlaw Highlands Retreat',
         backgroundColorTextUI = '#ff5a47',
         textColor = '#000000',
         displayTextPosition = 'top-center',
@@ -75,7 +75,7 @@ Config.GreenZones = { -- These are persistent greenzones that exist constantly, 
         blipColor = 2,
         blipScale = 0.8,
         blipAlpha = 100,
-        blipName = 'Another Greenzone'
+        blipName = 'Outlaw Highlands Retreat'
     }
     -- Create more zones here by following the same format as above
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,9 +2,9 @@ fx_version 'cerulean'
 game 'gta5'
 lua54 'yes'
 
-author 'iamlation'
-description 'A greenzones script to create controlled areas on the map for FiveM'
-version '1.0.1'
+author 'OutlawTwin Studio'
+description 'TwinCoder Outlaw GreenZone - stylish safe-zones with bilingual UI for FiveM'
+version '2.0.0'
 
 client_scripts {
     'client/*.lua'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,8 +19,8 @@ files {
 }
 
 shared_scripts {
-    'config.lua',
-    '@ox_lib/init.lua'
+    '@ox_lib/init.lua',
+    'config.lua'
 }
 
 ox_libs {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,6 +6,8 @@ author 'OutlawTwin Studio'
 description 'TwinCoder Outlaw GreenZone - stylish safe-zones with bilingual UI for FiveM'
 version '2.0.0'
 
+ui_page 'ui/index.html'
+
 client_scripts {
     'client/*.lua'
 }
@@ -16,6 +18,9 @@ server_scripts {
 
 files {
     'locales/*.json',
+    'ui/index.html',
+    'ui/style.css',
+    'ui/script.js'
 }
 
 shared_scripts {

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,7 +27,12 @@
         "blipID": "Blip ID",
         "blipIDDescription": "Sprite ID to display on the map",
         "blipColor": "Blip Color",
-        "blipColorDescription": "Color index for the sprite"
+        "blipColorDescription": "Color index for the sprite",
+        "confirm": "Confirm Outlaw Zone",
+        "cancel": "Cancel",
+        "radiusSuffix": "m",
+        "speedUnit": "MPH",
+        "speedUnlimited": "Unlimited"
     },
     "confirm": {
         "title": "Confirm Action",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,39 +1,62 @@
 {
     "notify": {
-        "greenzoneTitle": "Green Zone",
-        "greenzoneEnter": "You have entered a Green Zone and certain actions have been disabled",
-        "greenzoneExit": "You have exited a Green Zone and all actions have been restored"
+        "greenzoneTitle": "OutlawTwin Green Zone",
+        "greenzoneEnter": "You stepped into an OutlawTwin sanctuary; restricted gameplay is now in effect.",
+        "greenzoneExit": "You left the OutlawTwin sanctuary; full gameplay is restored."
     },
     "menu": {
-        "title": "Create Green Zone",
+        "title": "OutlawTwin Zone Designer",
+        "subtitle": "Configure a custom TwinCoder safe-space before pushing it live.",
         "blipName": "Blip Name",
-        "blipNameDescription": "The name of the Green Zone on the map",
-        "blipNamePlaceholder": "Green Zone",
-        "displayText": "Display Text",
-        "displayTextDescription": "Text to display on everyone's screen in this zone",
-        "displayTextPlaceholder": "Green Zone",
-        "displayTextColor": "Display Text Color",
-        "displayTextColorDescription": "The HTML color code of the text displayed",
-        "displayTextPosition": "Display Text Position",
-        "displayTextPositionDescription": "The position on the screen for the text",
+        "blipNameDescription": "Name of the Outlaw zone on the map",
+        "blipNamePlaceholder": "OutlawTwin Zone",
+        "displayText": "On-screen Banner",
+        "displayTextDescription": "Headline broadcast to players while inside",
+        "displayTextPlaceholder": "TwinCoder Safe Zone",
+        "displayTextColor": "Banner Color",
+        "displayTextColorDescription": "HTML color code of the banner background",
+        "displayTextPosition": "Banner Position",
+        "displayTextPositionDescription": "Screen position for the Outlaw banner",
         "positionRightCenter": "Right center",
         "positionLeftCenter": "Left center",
         "positionTopCenter": "Top center",
-        "size": "Size (radius)",
+        "size": "Radius",
         "disableFiring": "Disable Firing",
         "invincible": "Everyone Invincible",
         "speedLimit": "Speed Limit (MPH)",
         "blipID": "Blip ID",
-        "blipIDDescription": "The sprite ID to display on the map",
+        "blipIDDescription": "Sprite ID to display on the map",
         "blipColor": "Blip Color",
-        "blipColorDescription": "The blip color for the above sprite"
+        "blipColorDescription": "Color index for the sprite"
     },
     "confirm": {
         "title": "Confirm Action",
         "content": "Are you sure you want to delete your Green Zone?"
     },
     "commands": {
-        "setzone": "Create a temporary Green Zone",
-        "deletezone": "Delete a temporary Green Zone"
+        "setzone": "Create a temporary OutlawTwin Green Zone",
+        "deletezone": "Delete a temporary OutlawTwin Green Zone"
+    },
+    "ui": {
+        "designerTitle": "TwinCoder Outlaw Summary",
+        "designerDescription": "Review the configuration before broadcasting it to every Twin in town.",
+        "metadataLocation": "Location",
+        "metadataRadius": "Radius",
+        "metadataBanner": "Banner",
+        "metadataBannerPosition": "Banner Position",
+        "metadataSpeedLimit": "Speed Limit",
+        "metadataFiring": "Firing Lock",
+        "metadataInvincible": "Invincible",
+        "metadataBlip": "Blip",
+        "metadataBlipValue": "Sprite #%s • Color %s",
+        "speedUnlimited": "Unlimited",
+        "speedFormat": "%s MPH",
+        "booleanEnabled": "Enabled",
+        "booleanDisabled": "Disabled",
+        "confirm": "Publish Twin Zone",
+        "confirmDescription": "Send the configuration live to every outlaw twin online.",
+        "cancel": "Edit Again",
+        "cancelDescription": "Go back and tweak the configuration before publishing.",
+        "details": "Zone Details"
     }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,62 @@
+{
+    "notify": {
+        "greenzoneTitle": "Zone Verte OutlawTwin",
+        "greenzoneEnter": "Vous venez d'entrer dans un sanctuaire OutlawTwin ; certaines actions sont désormais limitées.",
+        "greenzoneExit": "Vous avez quitté le sanctuaire OutlawTwin ; toutes les actions sont rétablies."
+    },
+    "menu": {
+        "title": "Designer de Zone OutlawTwin",
+        "subtitle": "Configurez une zone sécurisée TwinCoder avant de la diffuser.",
+        "blipName": "Nom du blip",
+        "blipNameDescription": "Nom de la zone Outlaw sur la carte",
+        "blipNamePlaceholder": "Zone OutlawTwin",
+        "displayText": "Bannière à l'écran",
+        "displayTextDescription": "Titre affiché aux joueurs dans la zone",
+        "displayTextPlaceholder": "Zone sûre TwinCoder",
+        "displayTextColor": "Couleur de la bannière",
+        "displayTextColorDescription": "Code couleur HTML de la bannière",
+        "displayTextPosition": "Position de la bannière",
+        "displayTextPositionDescription": "Position à l'écran de la bannière Outlaw",
+        "positionRightCenter": "Centre droit",
+        "positionLeftCenter": "Centre gauche",
+        "positionTopCenter": "Centre haut",
+        "size": "Rayon",
+        "disableFiring": "Désactiver les tirs",
+        "invincible": "Tout le monde invincible",
+        "speedLimit": "Vitesse max (MPH)",
+        "blipID": "ID du blip",
+        "blipIDDescription": "ID du sprite affiché sur la carte",
+        "blipColor": "Couleur du blip",
+        "blipColorDescription": "Index de couleur du sprite"
+    },
+    "confirm": {
+        "title": "Confirmer l'action",
+        "content": "Êtes-vous sûr de vouloir supprimer votre zone verte ?"
+    },
+    "commands": {
+        "setzone": "Créer une zone verte OutlawTwin temporaire",
+        "deletezone": "Supprimer une zone verte OutlawTwin temporaire"
+    },
+    "ui": {
+        "designerTitle": "Récapitulatif TwinCoder Outlaw",
+        "designerDescription": "Vérifiez la configuration avant de la publier pour tous les Twins.",
+        "metadataLocation": "Position",
+        "metadataRadius": "Rayon",
+        "metadataBanner": "Bannière",
+        "metadataBannerPosition": "Position de la bannière",
+        "metadataSpeedLimit": "Vitesse",
+        "metadataFiring": "Blocage des tirs",
+        "metadataInvincible": "Invincible",
+        "metadataBlip": "Blip",
+        "metadataBlipValue": "Sprite n°%s • Couleur %s",
+        "speedUnlimited": "Illimitée",
+        "speedFormat": "%s MPH",
+        "booleanEnabled": "Activé",
+        "booleanDisabled": "Désactivé",
+        "confirm": "Publier la zone Twin",
+        "confirmDescription": "Diffuser la configuration à tous les outlaws connectés.",
+        "cancel": "Modifier encore",
+        "cancelDescription": "Revenir en arrière pour ajuster la configuration.",
+        "details": "Détails de la zone"
+    }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -27,7 +27,12 @@
         "blipID": "ID du blip",
         "blipIDDescription": "ID du sprite affiché sur la carte",
         "blipColor": "Couleur du blip",
-        "blipColorDescription": "Index de couleur du sprite"
+        "blipColorDescription": "Index de couleur du sprite",
+        "confirm": "Valider la zone",
+        "cancel": "Annuler",
+        "radiusSuffix": "m",
+        "speedUnit": "MPH",
+        "speedUnlimited": "Illimitée"
     },
     "confirm": {
         "title": "Confirmer l'action",

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,5 @@
+local locale = lib.locale()
+
 lib.addCommand(Config.GreenzonesCommand, {
     help = locale('commands.setzone'),
     restricted = 'group.admin'

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,6 @@
-local locale = lib.locale()
+local locale = lib and lib.locale or function(phrase)
+    return phrase
+end
 
 lib.addCommand(Config.GreenzonesCommand, {
     help = locale('commands.setzone'),

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,23 +1,21 @@
 lib.addCommand(Config.GreenzonesCommand, {
     help = locale('commands.setzone'),
     restricted = 'group.admin'
-}, function(source, args, raw)
-    local source = source
-    lib.callback('lation_greenzones:adminZone', source, cb)
+}, function(source)
+    lib.callback('outlawtwin_greenzones:adminZone', source, cb)
 end)
 
 lib.addCommand(Config.GreenzonesClearCommand, {
     help = locale('commands.deletezone'),
     restricted = 'group.admin'
-}, function(source, args, raw)
-    local source = source
-    lib.callback('lation_greenzones:adminZoneClear', source, cb)
+}, function(source)
+    lib.callback('outlawtwin_greenzones:adminZoneClear', source, cb)
 end)
 
-lib.callback.register('lation_greenzones:data', function(source, zoneCoords, zoneName, textUI, textUIColor, textUIPosition, zoneSize, disarm, invincible, speedLimit, blipID, blipColor)
-    TriggerClientEvent('lation_greenzones:createAdminZone', -1, zoneCoords, zoneName, textUI, textUIColor, textUIPosition, zoneSize, disarm, invincible, speedLimit, blipID, blipColor)
+lib.callback.register('outlawtwin_greenzones:data', function(source, zoneCoords, zoneName, textUI, textUIColor, textUIPosition, zoneSize, disarm, invincible, speedLimit, blipID, blipColor)
+    TriggerClientEvent('outlawtwin_greenzones:createAdminZone', -1, zoneCoords, zoneName, textUI, textUIColor, textUIPosition, zoneSize, disarm, invincible, speedLimit, blipID, blipColor)
 end)
 
-lib.callback.register('lation_greenzones:deleteZone', function()
-    TriggerClientEvent('lation_greenzones:deleteAdminZone', -1)
+lib.callback.register('outlawtwin_greenzones:deleteZone', function()
+    TriggerClientEvent('outlawtwin_greenzones:deleteAdminZone', -1)
 end)

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OutlawTwin Zone Designer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div id="app" class="designer designer--hidden">
+        <div class="designer__panel">
+            <header class="designer__header">
+                <div>
+                    <h1 id="title"></h1>
+                    <p id="subtitle"></p>
+                </div>
+                <div class="designer__badge">OutlawTwin</div>
+            </header>
+            <form id="designer-form" class="designer__form">
+                <div class="form__grid">
+                    <label class="field" for="blipName">
+                        <span class="field__label" id="label-blipName"></span>
+                        <input id="blipName" name="blipName" type="text" maxlength="32" autocomplete="off" />
+                        <small class="field__hint" id="hint-blipName"></small>
+                    </label>
+                    <label class="field" for="banner">
+                        <span class="field__label" id="label-banner"></span>
+                        <input id="banner" name="banner" type="text" maxlength="64" autocomplete="off" />
+                        <small class="field__hint" id="hint-banner"></small>
+                    </label>
+                    <div class="field field--color">
+                        <span class="field__label" id="label-bannerColor"></span>
+                        <div class="color-input">
+                            <input id="bannerColor" name="bannerColor" type="color" />
+                            <input id="bannerColorText" name="bannerColorText" type="text" maxlength="7" />
+                        </div>
+                        <small class="field__hint" id="hint-bannerColor"></small>
+                    </div>
+                    <label class="field" for="bannerPosition">
+                        <span class="field__label" id="label-bannerPosition"></span>
+                        <select id="bannerPosition" name="bannerPosition"></select>
+                        <small class="field__hint" id="hint-bannerPosition"></small>
+                    </label>
+                </div>
+
+                <div class="form__stack">
+                    <div class="slider-field">
+                        <div class="slider-field__header">
+                            <span id="label-radius"></span>
+                            <span class="slider-field__value"><span id="radius-value"></span> <span id="radius-suffix"></span></span>
+                        </div>
+                        <input id="radius" name="radius" type="range" min="1" max="100" step="1" />
+                    </div>
+
+                    <div class="toggle-row">
+                        <label class="toggle">
+                            <input id="disableFiring" name="disableFiring" type="checkbox" />
+                            <span id="label-disableFiring"></span>
+                        </label>
+                        <label class="toggle">
+                            <input id="invincible" name="invincible" type="checkbox" />
+                            <span id="label-invincible"></span>
+                        </label>
+                    </div>
+
+                    <div class="slider-field">
+                        <div class="slider-field__header">
+                            <span id="label-speedLimit"></span>
+                            <span class="slider-field__value"><span id="speed-value"></span></span>
+                        </div>
+                        <input id="speedLimit" name="speedLimit" type="range" min="0" max="120" step="5" />
+                    </div>
+
+                    <div class="form__grid">
+                        <label class="field" for="blipID">
+                            <span class="field__label" id="label-blipID"></span>
+                            <input id="blipID" name="blipID" type="number" min="1" max="826" />
+                            <small class="field__hint" id="hint-blipID"></small>
+                        </label>
+                        <label class="field" for="blipColor">
+                            <span class="field__label" id="label-blipColor"></span>
+                            <input id="blipColor" name="blipColor" type="number" min="1" max="85" />
+                            <small class="field__hint" id="hint-blipColor"></small>
+                        </label>
+                    </div>
+                </div>
+
+                <footer class="designer__footer">
+                    <button type="button" id="cancel" class="btn btn--ghost"></button>
+                    <button type="submit" id="confirm" class="btn btn--primary"></button>
+                </footer>
+            </form>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/ui/script.js
+++ b/ui/script.js
@@ -1,0 +1,180 @@
+const resource = window.GetParentResourceName ? window.GetParentResourceName() : 'Outlaw_GreenZone';
+const root = document.getElementById('app');
+const form = document.getElementById('designer-form');
+const colorHex = document.getElementById('bannerColorText');
+const colorPicker = document.getElementById('bannerColor');
+const radiusSlider = document.getElementById('radius');
+const speedSlider = document.getElementById('speedLimit');
+const radiusValue = document.getElementById('radius-value');
+const radiusSuffix = document.getElementById('radius-suffix');
+const speedValue = document.getElementById('speed-value');
+const cancelBtn = document.getElementById('cancel');
+const confirmBtn = document.getElementById('confirm');
+const bannerPosition = document.getElementById('bannerPosition');
+
+let labels = null;
+let defaults = null;
+let open = false;
+
+function clamp(val, min, max) {
+    return Math.min(Math.max(val, min), max);
+}
+
+function formatSpeed(value) {
+    if (!labels) return `${value}`;
+    if (Number(value) <= 0) {
+        return labels.helpers.unlimited;
+    }
+
+    return `${value} ${labels.helpers.speedUnit}`;
+}
+
+function applyLabels() {
+    document.getElementById('title').textContent = labels.title;
+    document.getElementById('subtitle').textContent = labels.subtitle;
+
+    cancelBtn.textContent = labels.actions.cancel;
+    confirmBtn.textContent = labels.actions.confirm;
+
+    Object.entries(labels.fields).forEach(([key, field]) => {
+        const label = document.getElementById(`label-${key}`);
+        const hint = document.getElementById(`hint-${key}`);
+        if (label) {
+            label.textContent = field.label || '';
+        }
+        if (hint) {
+            hint.textContent = field.description || '';
+        }
+        const input = document.getElementById(key);
+        if (input && field.placeholder) {
+            input.placeholder = field.placeholder;
+        }
+    });
+
+    radiusSuffix.textContent = labels.helpers.radiusSuffix;
+
+    bannerPosition.innerHTML = '';
+    labels.positions.forEach((option) => {
+        const element = document.createElement('option');
+        element.value = option.value;
+        element.textContent = option.label;
+        bannerPosition.appendChild(element);
+    });
+}
+
+function applyDefaults() {
+    document.getElementById('blipName').value = defaults.blipName || '';
+    document.getElementById('banner').value = defaults.banner || '';
+    document.getElementById('bannerColor').value = defaults.bannerColor || '#ff5a47';
+    document.getElementById('bannerColorText').value = (defaults.bannerColor || '#ff5a47').toUpperCase();
+    document.getElementById('bannerPosition').value = defaults.bannerPosition || 'top-center';
+    document.getElementById('disableFiring').checked = Boolean(defaults.disableFiring);
+    document.getElementById('invincible').checked = Boolean(defaults.invincible);
+
+    radiusSlider.value = clamp(Number(defaults.radius || 10), 1, 100);
+    speedSlider.value = clamp(Number(defaults.speedLimit || 0), 0, 120);
+    document.getElementById('blipID').value = Number(defaults.blipID || 487);
+    document.getElementById('blipColor').value = Number(defaults.blipColor || 1);
+
+    radiusValue.textContent = radiusSlider.value;
+    speedValue.textContent = formatSpeed(speedSlider.value);
+}
+
+function openDesigner(payload) {
+    labels = payload.labels;
+    defaults = payload.defaults;
+    if (payload.lang) {
+        document.documentElement.lang = payload.lang;
+    }
+
+    applyLabels();
+    applyDefaults();
+
+    root.classList.remove('designer--hidden');
+    open = true;
+}
+
+function closeDesigner() {
+    root.classList.add('designer--hidden');
+    open = false;
+}
+
+function post(action, data = {}) {
+    fetch(`https://${resource}/${action}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+        },
+        body: JSON.stringify(data),
+    }).catch(() => {});
+}
+
+window.addEventListener('message', (event) => {
+    if (!event.data || !event.data.action) return;
+
+    if (event.data.action === 'open') {
+        openDesigner(event.data);
+    }
+
+    if (event.data.action === 'close') {
+        closeDesigner();
+    }
+});
+
+function syncColorInputs(source) {
+    if (source === 'picker') {
+        colorHex.value = colorPicker.value.toUpperCase();
+    } else {
+        let value = colorHex.value.trim();
+        if (!value.startsWith('#')) value = `#${value}`;
+        if (/^#([0-9a-fA-F]{6})$/.test(value)) {
+            colorPicker.value = value.toUpperCase();
+            colorHex.value = value.toUpperCase();
+        }
+    }
+}
+
+colorPicker.addEventListener('input', () => syncColorInputs('picker'));
+colorHex.addEventListener('input', () => syncColorInputs('text'));
+
+radiusSlider.addEventListener('input', () => {
+    radiusValue.textContent = radiusSlider.value;
+});
+
+speedSlider.addEventListener('input', () => {
+    speedValue.textContent = formatSpeed(speedSlider.value);
+});
+
+cancelBtn.addEventListener('click', () => {
+    closeDesigner();
+    post('designerCancel');
+});
+
+form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    closeDesigner();
+    const data = {
+        blipName: document.getElementById('blipName').value,
+        banner: document.getElementById('banner').value,
+        bannerColor: document.getElementById('bannerColor').value,
+        bannerPosition: document.getElementById('bannerPosition').value,
+        radius: radiusSlider.value,
+        disableFiring: document.getElementById('disableFiring').checked,
+        invincible: document.getElementById('invincible').checked,
+        speedLimit: speedSlider.value,
+        blipID: document.getElementById('blipID').value,
+        blipColor: document.getElementById('blipColor').value,
+    };
+
+    post('designerSubmit', data);
+});
+
+window.addEventListener('keydown', (event) => {
+    if (!open) return;
+    if (event.key === 'Escape') {
+        closeDesigner();
+        post('designerEscape');
+    }
+});
+
+closeDesigner();

--- a/ui/style.css
+++ b/ui/style.css
@@ -46,6 +46,7 @@ body {
     pointer-events: none;
     opacity: 0;
     transform: translateY(20px);
+    visibility: hidden;
 }
 
 .designer__panel {

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,0 +1,297 @@
+:root {
+    color-scheme: dark;
+    font-family: 'Rajdhani', sans-serif;
+    --bg: rgba(10, 11, 15, 0.88);
+    --panel: rgba(22, 24, 31, 0.92);
+    --accent: #ff5a47;
+    --accent-hover: #ff735f;
+    --ghost: rgba(255, 255, 255, 0.12);
+    --ghost-hover: rgba(255, 255, 255, 0.2);
+    --border: rgba(255, 255, 255, 0.08);
+    --text: #f4f6fb;
+    --muted: rgba(244, 246, 251, 0.6);
+    --outline: rgba(255, 90, 71, 0.45);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: transparent;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text);
+}
+
+.designer {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: radial-gradient(circle at 20% -20%, rgba(255, 90, 71, 0.25), transparent 55%),
+        radial-gradient(circle at 80% 120%, rgba(114, 230, 143, 0.15), transparent 45%);
+    transition: opacity 0.2s ease, transform 0.25s ease;
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.designer--hidden {
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(20px);
+}
+
+.designer__panel {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    width: min(720px, 92vw);
+    padding: 28px;
+    border-radius: 16px;
+    box-shadow: 0 32px 64px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    backdrop-filter: blur(16px);
+}
+
+.designer__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.designer__header h1 {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.designer__header p {
+    font-size: 15px;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
+.designer__badge {
+    background: rgba(255, 90, 71, 0.18);
+    color: var(--accent);
+    border: 1px solid rgba(255, 90, 71, 0.35);
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 12px;
+    align-self: flex-start;
+}
+
+.designer__form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.form__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.form__stack {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.field__label {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.field__hint {
+    font-size: 12px;
+    color: var(--muted);
+    letter-spacing: 0.02em;
+}
+
+.field input,
+.field select {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 10px 14px;
+    color: var(--text);
+    font-family: inherit;
+    font-size: 15px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+    outline: none;
+    border-color: var(--outline);
+    box-shadow: 0 0 0 2px rgba(255, 90, 71, 0.12);
+}
+
+.field--color .color-input {
+    display: grid;
+    grid-template-columns: 60px 1fr;
+    gap: 10px;
+}
+
+.field--color input[type='color'] {
+    padding: 0;
+    height: 44px;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+}
+
+.field--color input[type='text'] {
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+}
+
+.slider-field {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.slider-field__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-transform: uppercase;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.slider-field__value {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.slider-field input {
+    -webkit-appearance: none;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    outline: none;
+}
+
+.slider-field input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    box-shadow: 0 0 0 4px rgba(255, 90, 71, 0.25);
+}
+
+.slider-field input::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: none;
+}
+
+.toggle-row {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 10px 16px;
+    border-radius: 12px;
+    text-transform: uppercase;
+    font-size: 13px;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+}
+
+.toggle input {
+    accent-color: var(--accent);
+    width: 18px;
+    height: 18px;
+}
+
+.designer__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+    margin-top: 6px;
+}
+
+.btn {
+    border: none;
+    padding: 12px 28px;
+    border-radius: 999px;
+    font-family: inherit;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.btn--primary {
+    background: var(--accent);
+    color: #1a0907;
+    box-shadow: 0 12px 24px rgba(255, 90, 71, 0.3);
+}
+
+.btn--primary:hover {
+    background: var(--accent-hover);
+    transform: translateY(-1px);
+}
+
+.btn--ghost {
+    background: var(--ghost);
+    color: var(--text);
+}
+
+.btn--ghost:hover {
+    background: var(--ghost-hover);
+}
+
+@media (max-width: 640px) {
+    .form__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .designer__panel {
+        padding: 22px;
+    }
+}


### PR DESCRIPTION
## Summary
- restyled the admin designer flow with a TwinCoder-branded review context and renamed network events
- refreshed configuration defaults, metadata, and presets with OutlawTwin naming
- documented the resource and added bilingual (en/fr) locale files for UI strings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd954992708328961f3181ff17f45e